### PR TITLE
fixed invalid selector error when id starts with a number

### DIFF
--- a/src/force.js
+++ b/src/force.js
@@ -476,7 +476,7 @@ var force = function() {
             [].forEach.call(hashLinkElements, function(el) {
         		el.addEventListener('click', function(ev) {
         			if (window.location.pathname.replace(/^\//, '') == this.pathname.replace(/^\//, '') && window.location.hostname == this.hostname) {
-        		        var target = document.querySelector(this.hash);
+        		        var target = document.getElementById(this.hash.slice(1));
                     target && jump(target);
                     ev.preventDefault();
         		    }


### PR DESCRIPTION
When an ID starts with a number, the querySelector call was generating an error. This should also be a little faster as I believe getElementById is the fastest way to target an element.